### PR TITLE
Despause Lavalink if is playing nothing and better logs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -164,15 +164,22 @@ impl EventHandler for HydrogenHandler {
 
         let option_manager = self.context.manager.read().await.clone();
         if let Some(manager) = option_manager {
-            if let Err(e) = manager.update_voice_state(old, new).await {
-                warn!("(voice_state_update): cannot update the HydrogenManager's player voice state: {}", e);
+            match manager.update_voice_state(old, new).await {
+                Ok(updated) => {
+                    if updated {
+                        info!(
+                            "(voice_state_update): processed in {}ms...",
+                            timer.elapsed().as_millis()
+                        );
+                    } else {
+                        debug!("(voice_state_update): ignored");
+                    }
+                }
+                Err(e) => {
+                    warn!("(voice_state_update): cannot update the HydrogenManager's player voice state: {}", e);
+                }
             }
         }
-
-        info!(
-            "(voice_state_update): processed in {}ms",
-            timer.elapsed().as_millis()
-        );
     }
 
     async fn voice_server_update(&self, _: Context, voice_server: VoiceServerUpdateEvent) {
@@ -181,15 +188,22 @@ impl EventHandler for HydrogenHandler {
 
         let option_manager = self.context.manager.read().await.clone();
         if let Some(manager) = option_manager {
-            if let Err(e) = manager.update_voice_server(voice_server).await {
-                warn!("(voice_server_update): cannot update HydrogenManager's player voice server: {}", e);
+            match manager.update_voice_server(voice_server).await {
+                Ok(updated) => {
+                    if updated {
+                        info!(
+                            "(voice_server_update): processed in {}ms...",
+                            timer.elapsed().as_millis()
+                        );
+                    } else {
+                        debug!("(voice_server_update): ignored");
+                    }
+                }
+                Err(e) => {
+                    warn!("(voice_server_update): cannot update HydrogenManager's player voice server: {}", e);
+                }
             }
         }
-
-        info!(
-            "(voice_server_update): processed in {}ms...",
-            timer.elapsed().as_millis()
-        );
     }
 }
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -267,14 +267,14 @@ impl HydrogenManager {
         &self,
         old_voice_state: Option<VoiceState>,
         voice_state: VoiceState,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         let players = self.player.read().await;
 
         let guild_id = voice_state
             .guild_id
             .ok_or(HydrogenManagerError::GuildIdMissing)?;
         let Some(player) = players.get(&guild_id) else {
-            return Ok(());
+            return Ok(false);
         };
 
         {
@@ -293,7 +293,7 @@ impl HydrogenManager {
 
                             self.destroy(guild_id).await?;
 
-                            return Ok(());
+                            return Ok(true);
                         }
                     }
                 }
@@ -338,17 +338,17 @@ impl HydrogenManager {
             }
         }
 
-        Ok(())
+        Ok(true)
     }
 
-    pub async fn update_voice_server(&self, voice_server: VoiceServerUpdateEvent) -> Result<()> {
+    pub async fn update_voice_server(&self, voice_server: VoiceServerUpdateEvent) -> Result<bool> {
         let players = self.player.read().await;
 
         let guild_id = voice_server
             .guild_id
             .ok_or(HydrogenManagerError::GuildIdMissing)?;
         let Some(player) = players.get(&guild_id) else {
-            return Ok(());
+            return Ok(false);
         };
 
         {
@@ -366,7 +366,7 @@ impl HydrogenManager {
             .await
             .map_err(|e| HydrogenManagerError::Player(e))?;
 
-        Ok(())
+        Ok(true)
     }
 
     pub async fn destroy(&self, guild_id: GuildId) -> Result<()> {

--- a/src/player.rs
+++ b/src/player.rs
@@ -387,6 +387,8 @@ impl HydrogenPlayer {
             }
 
             self.index.store(index, Ordering::Relaxed);
+            self.paused.store(false, Ordering::Relaxed);
+
             playing = self.start_playing().await?;
             if playing {
                 this_play_track = self.queue.read().await.get(index).cloned();


### PR DESCRIPTION
## Better Logs

Voice server and state updates produces useless logs when completed, spamming, so now, if the functions from the PlayerMananger returns that nothing has been updated, only a log in debug level with 'ignored' message will be produced. If PlayerManager returns that somethings has been updated, a normal 'processed' log will be produced.